### PR TITLE
Support drifting gratings with multiple center coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ significant flexibility and control in creative experimental design.
 It can also interact with a National Instrument equipment to receive 
 trigger and emit timing signals.
   
-Please check the '\examples\visual_stimulation' folder for
-example script `example_stimulation.py` of visual stimulation.
+Please check the '\examples' folder for
+example scripts of visual stimulation.
 
 ### Contributors:
 * Jun Zhuang @zhuangj
 * John Yearseley @yearsj
 * Derric Williams @derricw
+* Sumiya Kuroda @sumiya-kuroda
 
 ### Level of support
 We are planning on occasional updating this tool with no fixed schedule. Community involvement is encouraged through both issues and pull requests.

--- a/WarpedVisualStim/DisplayLogAnalysis.py
+++ b/WarpedVisualStim/DisplayLogAnalysis.py
@@ -116,7 +116,7 @@ class DisplayLogAnalyzer(object):
             stim_name = self.log_dict['stimulation']['stim_name']
             if stim_name in ['UniformContrast', 'FlashingCircle', 'SparseNoise', 'LocallySparseNoise',
                              'DriftingGratingCirlce', 'StaticGratingCircle', 'StaticImages', 'StimulusSeparator',
-                             'SinusoidalLuminance']:
+                             'SinusoidalLuminance', 'DriftingGratingMultipleCircle']:
                 curr_stim_name = '{:03d}_{}RetinotopicMapping'.format(0, stim_name)
                 curr_dict = self.log_dict['stimulation']
                 curr_dict['stim_name'] = curr_stim_name
@@ -240,6 +240,16 @@ class DisplayLogAnalyzer(object):
                 elif curr_stim_n[-38:] == '_SinusoidalLuminanceRetinotopicMapping':
                     str_sl = 'onset'
                     curr_pd_onset.update({'str_stim': str_sl})
+                elif curr_stim_n[-48:] == '_DriftingGratingMultipleCircleRetinotopicMapping':
+                    str_dgc = 'alt{:06.1f}_azi{:06.1f}_sf{:04.2f}_tf{:04.1f}_dire{:03d}_con{:04.2f}_rad{:03d}'\
+                        .format(onset_frame[7][0],
+                                onset_frame[7][1],
+                                onset_frame[2],
+                                onset_frame[3],
+                                int(onset_frame[4]),
+                                onset_frame[5],
+                                int(onset_frame[6]))
+                    curr_pd_onset.update({'str_stim': str_dgc})
                 else:
                     raise LookupError('Do not understand stimulus name: {}'.format(curr_stim_n))
 
@@ -298,7 +308,8 @@ class DisplayLogAnalyzer(object):
                 curr_pd_onsets_com.update(self._analyze_pd_onset_combined_general(curr_pd_onsets_seq))
             elif stim_n[-37:] == '_LocallySparseNoiseRetinotopicMapping':
                 curr_pd_onsets_com.update(self._analyze_pd_onset_combined_locally_sparse_noise(curr_pd_onsets_seq))
-            elif stim_n[-40:] == '_DriftingGratingCircleRetinotopicMapping':
+            elif (stim_n[-40:] == '_DriftingGratingCircleRetinotopicMapping') \
+                or (stim_n[-48:] == '_DriftingGratingMultipleCircleRetinotopicMapping'):
                 dgc_pd_onsets_com = self._analyze_pd_onset_combined_drifting_grating_circle(curr_pd_onsets_seq)
 
                 if is_dgc_blocked:

--- a/WarpedVisualStim/examples/example_drifting_grating_circle_multiple.py
+++ b/WarpedVisualStim/examples/example_drifting_grating_circle_multiple.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""
+the minimum script to run 10 seconds of black screen
+"""
+
+import matplotlib.pyplot as plt
+import WarpedVisualStim.StimulusRoutines as stim
+from WarpedVisualStim.MonitorSetup import Monitor, Indicator
+from WarpedVisualStim.DisplayStimulus import DisplaySequence
+
+# Initialize Monitor object
+mon = Monitor(resolution=(1200, 1920), dis=15., mon_width_cm=52., mon_height_cm=32.)
+ind = Indicator(mon)
+ds = DisplaySequence(log_dir='C:/data', is_by_index=True, display_screen=1)
+dgc = stim.DriftingGratingMultipleCircle(monitor=mon, indicator=ind, background=0.,
+                                 coordinate='degree', center_list=[(10., 90.),(0., 80.)], sf_list=(0.02,),
+                                 tf_list=(4.0, 2.0), dire_list=(45.,), con_list=(0.8,), radius_list=(20.,),
+                                 block_dur=2., midgap_dur=1., iteration=3, pregap_dur=2.,
+                                 postgap_dur=3., is_blank_block=True, is_random_start_phase=False)
+ds.set_stim(dgc)
+ds.trigger_display()
+plt.show()

--- a/WarpedVisualStim/examples/example_log_analysis.py
+++ b/WarpedVisualStim/examples/example_log_analysis.py
@@ -1,0 +1,14 @@
+from WarpedVisualStim.DisplayLogAnalysis import DisplayLogAnalyzer
+
+import argparse
+from WarpedVisualStim.tools import FileTools as ft
+parser = argparse.ArgumentParser(description='Posthoc analysis on display_log files') 
+parser.add_argument('-i', '--input', help='<Required> Absolute path to display_log (.pkl) file', type=ft.validate_file, required=True)
+args = parser.parse_args()
+
+dla = DisplayLogAnalyzer(args.input)
+stim_dict = dla.get_stim_dict()
+pd_onsets_seq = dla.analyze_photodiode_onsets_sequential(stim_dict, pd_thr=-0.5)
+pd_onsets_combined = dla.analyze_photodiode_onsets_combined(pd_onsets_seq)
+
+print(pd_onsets_combined)

--- a/WarpedVisualStim/tools/FileTools.py
+++ b/WarpedVisualStim/tools/FileTools.py
@@ -7,6 +7,9 @@ import shutil
 import h5py
 import datetime
 from . import ImageAnalysis as ia
+import os
+import argparse
+from pathlib import Path
 
 try:
     import tifffile as tf
@@ -635,6 +638,19 @@ def int2str(num, length=None):
 #
 #    return mov
 
+def validate_file(f):
+    if not os.path.exists(f):
+        # Argparse uses the ArgumentTypeError to give a rejection message like:
+        # error: argument input: x does not exist
+        raise argparse.ArgumentTypeError("{0} does not exist".format(f))
+    return get_abspath(f)
+
+def get_abspath(relpath_from_this_file, pathlib=True):
+    base = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if pathlib:
+        return Path(os.path.abspath(os.path.join(base, relpath_from_this_file)))
+    else:
+        return os.path.abspath(os.path.join(base, relpath_from_this_file))
 
 if __name__ == '__main__':
     # ----------------------------------------------------------------------------


### PR DESCRIPTION
In order to support drifting gratings with multiple center coordinates, I added a new class `DriftingGratingMultipleCircle`. Because this is a new class, it will not interfere with existing scripts that current users are running. Its usage is pretty much the same as the `DriftingGratingCircle`, except now it accepts multiple center coordinates specified with the new argument `center_list`.

This PR fixes #4 